### PR TITLE
Import trusty action packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/stacklok/trusty-sdk-go
+
+go 1.22.1
+
+require (
+	github.com/BurntSushi/toml v1.3.2
+	github.com/google/go-github/v61 v61.0.0
+	golang.org/x/oauth2 v0.20.0
+)
+
+require github.com/google/go-querystring v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5pNlu1go=
+github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/oauth2 v0.20.0 h1:4mQdhULixXKP1rwYBW0vAijoXnkTG0BLCDRzfe1idMo=
+golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/githubapi/githubapi.go
+++ b/pkg/githubapi/githubapi.go
@@ -1,0 +1,60 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubapi
+
+import (
+	"context"
+
+	"github.com/google/go-github/v61/github" // Make sure to use the version of go-github you need
+	"golang.org/x/oauth2"
+)
+
+// GitHubClient wraps the GitHub client and its context
+type GitHubClient struct {
+	Client *github.Client
+	Ctx    context.Context
+}
+
+// NewGitHubClient initializes and returns a new GitHubClient
+func NewGitHubClient(token string) *GitHubClient {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	client := github.NewClient(tc)
+
+	return &GitHubClient{
+		Client: client,
+		Ctx:    ctx,
+	}
+}
+
+// GetFileContent fetches the content of a file from a specific branch in a repository
+func (g *GitHubClient) GetFileContent(owner, repo, path, ref string) (string, error) {
+	opts := &github.RepositoryContentGetOptions{Ref: ref}
+	fileContent, _, _, err := g.Client.Repositories.GetContents(g.Ctx, owner, repo, path, opts)
+	if err != nil {
+		return "", err
+	}
+
+	content, err := fileContent.GetContent()
+	if err != nil {
+		return "", err
+	}
+
+	return content, nil
+}

--- a/pkg/parser/cargo.go
+++ b/pkg/parser/cargo.go
@@ -1,0 +1,39 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"github.com/BurntSushi/toml"
+	"github.com/stacklok/trusty-sdk-go/pkg/types"
+)
+
+// ParseCargoToml parses the content of a Cargo.toml file and returns a slice of dependencies.
+// It takes a string parameter `content` which represents the content of the Cargo.toml file.
+// The function returns a slice of `types.Dependency` and an error if any occurred during parsing.
+func ParseCargoToml(content string) ([]types.Dependency, error) {
+	var conf struct {
+		Dependencies map[string]string `toml:"dependencies"`
+	}
+	if _, err := toml.Decode(content, &conf); err != nil {
+		return nil, err
+	}
+
+	var deps []types.Dependency
+	for name, version := range conf.Dependencies {
+		deps = append(deps, types.Dependency{Name: name, Version: version})
+	}
+	return deps, nil
+}

--- a/pkg/parser/gomod.go
+++ b/pkg/parser/gomod.go
@@ -1,0 +1,67 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"strings"
+
+	"github.com/stacklok/trusty-sdk-go/pkg/types"
+)
+
+// ParseGoMod parses the content of a go.mod file and returns a slice of dependencies.
+// Each dependency is represented by a types.Dependency struct, containing the name and version.
+func ParseGoMod(content string) ([]types.Dependency, error) {
+	var deps []types.Dependency
+	lines := strings.Split(content, "\n")
+	inRequireBlock := false // Flag to track whether we are inside a require block
+
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" || strings.HasPrefix(trimmedLine, "//") {
+			continue // Skip empty lines and comments
+		}
+
+		if strings.HasPrefix(trimmedLine, "require (") {
+			inRequireBlock = true // We're entering a require block
+			continue
+		}
+
+		if trimmedLine == ")" && inRequireBlock {
+			inRequireBlock = false // We're leaving a require block
+			continue
+		}
+
+		if inRequireBlock || strings.HasPrefix(trimmedLine, "require") {
+			parts := strings.Fields(trimmedLine)
+			if len(parts) >= 2 {
+				var depName, depVersion string
+				if inRequireBlock {
+					depName = parts[0]
+					depVersion = parts[1]
+				} else { // Inline require
+					if len(parts) < 3 {
+						continue // Skip malformed inline requires that do not have both a name and a version
+					}
+					depName = parts[1]
+					depVersion = parts[2]
+				}
+				deps = append(deps, types.Dependency{Name: depName, Version: depVersion})
+			}
+		}
+	}
+
+	return deps, nil
+}

--- a/pkg/parser/packagejson.go
+++ b/pkg/parser/packagejson.go
@@ -1,0 +1,38 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"encoding/json"
+
+	"github.com/stacklok/trusty-sdk-go/pkg/types"
+)
+
+// ParsePackageJSON parses package.json content and extracts dependencies
+func ParsePackageJSON(content string) ([]types.Dependency, error) {
+	var parsedContent struct {
+		Dependencies map[string]string `json:"dependencies"`
+	}
+	if err := json.Unmarshal([]byte(content), &parsedContent); err != nil {
+		return nil, err
+	}
+
+	var deps []types.Dependency
+	for name, version := range parsedContent.Dependencies {
+		deps = append(deps, types.Dependency{Name: name, Version: version})
+	}
+	return deps, nil
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,0 +1,72 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"log"
+	"strings"
+
+	"github.com/stacklok/trusty-sdk-go/pkg/types"
+)
+
+// ParsingFunction is a function type that takes a string as input and returns
+// a slice of dependencies and an error.
+type ParsingFunction func(string) ([]types.Dependency, error)
+
+var parsingFunctions = map[string]ParsingFunction{
+	"go.mod":           ParseGoMod,
+	"Cargo.toml":       ParseCargoToml,
+	"requirements.txt": ParseRequirementsTxt,
+	"pom.xml":          ParsePomXml,
+	"package.json":     ParsePackageJSON,
+}
+
+// Parse parses the given filename and content to extract dependencies and
+// determine the ecosystem. It iterates through the available parsing function
+// based on the file suffix and calls the appropriate function.
+// If a matching parsing function is found, it returns the extracted dependencies,
+// the determined ecosystem, and any error encountered.
+// If no matching parsing function is found, it returns an empty slice of
+// dependencies, "none" as the ecosystem, and no error.
+func Parse(filename string, content string) ([]types.Dependency, string, error) {
+	log.Printf("Parsing file: %s\n", filename)
+	for suffix, function := range parsingFunctions {
+		if strings.HasSuffix(filename, suffix) {
+			deps, err := function(content)
+			ecosystem := determineEcosystem(suffix)
+			return deps, ecosystem, err
+		}
+	}
+	return []types.Dependency{}, "none", nil
+}
+
+// determineEcosystem maps a file suffix to its ecosystem
+func determineEcosystem(suffix string) string {
+	switch suffix {
+	case "go.mod":
+		return "go"
+	case "Cargo.toml":
+		return "crates"
+	case "requirements.txt":
+		return "pypi"
+	case "pom.xml":
+		return "maven"
+	case "package.json":
+		return "npm"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,0 +1,85 @@
+package parser
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stacklok/trusty-sdk-go/pkg/types"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		filename  string
+		content   string
+		expected  []types.Dependency
+		ecosystem string
+		err       error
+	}{
+		{
+			filename:  "meh.txt",
+			content:   "some content",
+			expected:  []types.Dependency{},
+			ecosystem: "none",
+			err:       nil,
+		},
+		{
+			filename: "package.json",
+			content:  "{\"dependencies\": {\"express\": \"^4.17.1\", \"lodash\": \"^4.17.21\"}}",
+			expected: []types.Dependency{
+				{Name: "express", Version: "^4.17.1"},
+				{Name: "lodash", Version: "^4.17.21"},
+			},
+			ecosystem: "npm",
+			err:       nil,
+		},
+		{
+			filename: "go.mod",
+			content:  "module example.com\n\ngo 1.16\n\nrequire (\n\tgithub.com/google/go-github/v60 v60.0.0\n)",
+			expected: []types.Dependency{
+				{Name: "github.com/google/go-github/v60", Version: "v60.0.0"},
+			},
+			ecosystem: "go",
+			err:       nil,
+		},
+		{
+			filename: "Cargo.toml",
+			content:  "[dependencies]\nrand = \"0.8.4\"\n",
+			expected: []types.Dependency{
+				{Name: "rand", Version: "0.8.4"},
+			},
+			ecosystem: "crates",
+			err:       nil,
+		},
+		{
+			filename: "requirements.txt",
+			content:  "requests==2.25.1\n",
+			expected: []types.Dependency{
+				{Name: "requests", Version: "2.25.1"},
+			},
+			ecosystem: "pypi",
+			err:       nil,
+		},
+		{
+			filename: "pom.xml",
+			content:  "<project>\n\t<dependencies>\n\t\t<dependency>\n\t\t\t<groupId>org.apache.maven</groupId>\n\t\t\t<artifactId>maven-core</artifactId>\n\t\t\t<version>3.8.1</version>\n\t\t</dependency>\n\t</dependencies>\n</project>",
+			expected: []types.Dependency{
+				{Name: "org.apache.maven:maven-core", Version: "3.8.1"},
+			},
+			ecosystem: "maven",
+			err:       nil,
+		},
+	}
+
+	for _, test := range tests {
+		deps, ecosystem, err := Parse(test.filename, test.content)
+		if !reflect.DeepEqual(deps, test.expected) {
+			t.Errorf("Expected dependencies %v, but got %v", test.expected, deps)
+		}
+		if ecosystem != test.ecosystem {
+			t.Errorf("Expected ecosystem %s, but got %s", test.ecosystem, ecosystem)
+		}
+		if err != test.err {
+			t.Errorf("Expected error %v, but got %v", test.err, err)
+		}
+	}
+}

--- a/pkg/parser/pomxml.go
+++ b/pkg/parser/pomxml.go
@@ -1,0 +1,50 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"encoding/xml"
+
+	"github.com/stacklok/trusty-sdk-go/pkg/types"
+)
+
+// ParsePomXml parses the content of a POM XML file and returns a slice of dependencies
+// along with their group ID, artifact ID, and version.
+// The content parameter is the string representation of the POM XML file.
+// The function returns a slice of types.Dependency and an error.
+// If the parsing is successful, the slice of dependencies is populated and the error is nil.
+// If an error occurs during parsing, the function returns nil for the slice of dependencies
+// and the error that occurred.
+func ParsePomXml(content string) ([]types.Dependency, error) {
+	var project struct {
+		Dependencies struct {
+			Dependency []struct {
+				GroupId    string `xml:"groupId"`
+				ArtifactId string `xml:"artifactId"`
+				Version    string `xml:"version"`
+			} `xml:"dependency"`
+		} `xml:"dependencies"`
+	}
+	if err := xml.Unmarshal([]byte(content), &project); err != nil {
+		return nil, err
+	}
+
+	var deps []types.Dependency
+	for _, d := range project.Dependencies.Dependency {
+		deps = append(deps, types.Dependency{Name: d.GroupId + ":" + d.ArtifactId, Version: d.Version})
+	}
+	return deps, nil
+}

--- a/pkg/parser/requirements.go
+++ b/pkg/parser/requirements.go
@@ -1,0 +1,40 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"strings"
+
+	"github.com/stacklok/trusty-sdk-go/pkg/types"
+)
+
+// ParseRequirementsTxt parses requirements.txt content and extracts dependencies
+func ParseRequirementsTxt(content string) ([]types.Dependency, error) {
+	var deps []types.Dependency
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "#") {
+			parts := strings.SplitN(line, "==", 2)
+			if len(parts) == 2 {
+				// Convert package name to lowercase
+				packageName := strings.ToLower(parts[0])
+				deps = append(deps, types.Dependency{Name: packageName, Version: parts[1]})
+			}
+		}
+	}
+	return deps, nil
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,42 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// Dependency represents a generic dependency structure
+type Dependency struct {
+	Name    string
+	Version string
+}
+
+// ConvertDepsToMap converts a slice of Dependency structs to a map for easier comparison
+func ConvertDepsToMap(deps []Dependency) map[string]string {
+	depMap := make(map[string]string)
+	for _, dep := range deps {
+		depMap[dep.Name] = dep.Version
+	}
+	return depMap
+}
+
+// DiffDependencies compares two sets of dependencies (represented as maps) and finds what's added in newDeps.
+func DiffDependencies(oldDeps, newDeps map[string]string) map[string]string {
+	addedDeps := make(map[string]string)
+	for dep, version := range newDeps {
+		if _, exists := oldDeps[dep]; !exists {
+			addedDeps[dep] = version
+		}
+	}
+	return addedDeps
+}

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,72 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestConvertDepsToMap tests the ConvertDepsToMap function for converting a slice of Dependency structs to a map
+func TestConvertDepsToMap(t *testing.T) {
+	deps := []Dependency{
+		{Name: "dep1", Version: "1.0"},
+		{Name: "dep2", Version: "2.0"},
+	}
+
+	expected := map[string]string{
+		"dep1": "1.0",
+		"dep2": "2.0",
+	}
+
+	result := ConvertDepsToMap(deps)
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+// TestDiffDependencies tests the DiffDependencies function for finding added dependencies
+func TestDiffDependencies(t *testing.T) {
+	oldDeps := map[string]string{
+		"dep1": "1.0",
+	}
+
+	newDeps := map[string]string{
+		"dep1": "1.0",
+		"dep2": "2.0",
+	}
+
+	expectedAdded := map[string]string{
+		"dep2": "2.0",
+	}
+
+	addedDeps := DiffDependencies(oldDeps, newDeps)
+	if !reflect.DeepEqual(addedDeps, expectedAdded) {
+		t.Errorf("Expected added dependencies %v, got %v", expectedAdded, addedDeps)
+	}
+
+	// Test case where there are no new dependencies added
+	newDepsSame := map[string]string{
+		"dep1": "1.0",
+	}
+
+	expectedEmpty := map[string]string{}
+
+	addedDepsSame := DiffDependencies(oldDeps, newDepsSame)
+	if !reflect.DeepEqual(addedDepsSame, expectedEmpty) {
+		t.Errorf("Expected no added dependencies, got %v", addedDepsSame)
+	}
+}


### PR DESCRIPTION
This takes packages from https://github.com/stacklok/trusty-action and
uses them here.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
