### PR TITLE
golangci-lint config and fixes

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,26 @@
+# Copyright 2024 Stacklok, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+name: golangci-lint
+
+on:
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: '1.22'
+          check-latest: true
+          cache: true
+      - name: lint
+        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
+        with:
+          version: v1.58
+          args: --timeout=5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,101 @@
+run:
+  issues-exit-code: 1
+  timeout: 5m
+
+linters-settings:
+  lll:
+    line-length: 130
+  gocyclo:
+    min-complexity: 15
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/stacklok/trusty-sdk-go)
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    errorCode: 0
+    warningCode: 0
+    rules:
+      - name: blank-imports
+        severity: warning
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: duplicated-imports
+      - name: error-naming
+      # - name: error-strings #BDG: This was enabled for months, but it suddenly started working on 3/2/2022.. come to find out we have TONS of error messages starting with capital... disabling for now(ever?)
+      - name: error-return
+      - name: exported
+        severity: error
+      - name: if-return
+      # - name: get-return // BDG: We have a lot of API endpoint handlers named like getFoos but write to response vs return... maybe later can figure that out
+      - name: identical-branches
+      - name: indent-error-flow
+      - name: import-shadowing
+      - name: package-comments
+      # NOTE: range-val-address and range-val-in-closure are irrelevant in Go 1.22 and later
+      - name: redefines-builtin-id
+      - name: struct-tag
+      - name: unconditional-recursion
+      - name: unnecessary-stmt
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: unused-receiver
+      - name: unhandled-error
+        disabled: true
+  gosec:
+    excludes:
+      - G114 # for the moment we need to use listenandserve that has no support for timeouts
+      - G404 # use unsafe random generator until logic change is discussed
+      - G307 # Deferring unsafe method "Close" on type "io.ReadCloser"
+      - G601 # Irrelevant for Go 1.22 and later, see: https://github.com/securego/gosec/issues/1099
+
+  depguard:
+    rules:
+      prevent_unmaintained_packages:
+        list-mode: lax # allow unless explicitely denied
+        files:
+          - $all
+          - "!$test"
+        deny:
+          - pkg: io/ioutil
+            desc: "this is deprecated"
+
+linters:
+  disable-all: true
+  enable:
+    - lll
+    - exhaustive
+    - depguard
+    - goconst
+    - gocyclo
+    - gofmt
+    - gosec
+    - gci
+    - unparam
+    - gosimple
+    - govet
+    - ineffassign
+    - paralleltest
+    - promlinter
+    - revive
+    - staticcheck
+    - unused
+    - thelper
+    - tparallel
+
+issues:
+  exclude-use-default: false
+  exclude-rules:
+    - path: '(.+)_test\.go'
+      linters:
+        - lll
+
+output:
+  formats:
+    - format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+  sort-results: true

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -23,8 +23,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stacklok/trusty-sdk-go/pkg/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/trusty-sdk-go/pkg/types"
 )
 
 // fakeClient mocks the http client used by the trusty client

--- a/pkg/githubapi/githubapi.go
+++ b/pkg/githubapi/githubapi.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package githubapi offers some utility functions to interact with GitHub from
+// the Trusty libraries.
 package githubapi
 
 import (

--- a/pkg/parser/cargo.go
+++ b/pkg/parser/cargo.go
@@ -17,6 +17,7 @@ package parser
 
 import (
 	"github.com/BurntSushi/toml"
+
 	"github.com/stacklok/trusty-sdk-go/pkg/types"
 )
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package parser exposes methods to decode dependency information from the
+// supported packaging ecosystems.
 package parser
 
 import (

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestParse(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		filename  string
 		content   string

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -22,6 +22,7 @@ import (
 
 // TestConvertDepsToMap tests the ConvertDepsToMap function for converting a slice of Dependency structs to a map
 func TestConvertDepsToMap(t *testing.T) {
+	t.Parallel()
 	deps := []Dependency{
 		{Name: "dep1", Version: "1.0"},
 		{Name: "dep2", Version: "2.0"},
@@ -40,6 +41,7 @@ func TestConvertDepsToMap(t *testing.T) {
 
 // TestDiffDependencies tests the DiffDependencies function for finding added dependencies
 func TestDiffDependencies(t *testing.T) {
+	t.Parallel()
 	oldDeps := map[string]string{
 		"dep1": "1.0",
 	}


### PR DESCRIPTION
This PR adds the golangci-lint configuration to the repository:

- Adds the linter config based on minder's
- Fixess all lining errors in the code
- Adds a workflow to run the linter as a presubmit

Note: requires https://github.com/stacklok/trusty-sdk-go/pull/12 and a rebase for the linter test to pass

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@stacklok.com>
