### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -22,5 +22,5 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
-          version: v1.58
+          version: v1.59
           args: --timeout=5m

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+# Copyright 2024 Stacklok, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # needed to write releases 
+
+    steps:
+      - name: Set tag name
+        shell: bash
+        run: |
+          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v3
+        with:
+          go-version: '1.22'
+          check-latest: true
+  
+      - name: Check out code
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          fetch-depth: 1
+      - name: Install bom
+        uses: kubernetes-sigs/release-actions/setup-bom@2f8b9ec22aedc9ce15039b6c7716aa6c2907df1c # v0.2.0
+      - name: Generate SBOM
+        shell: bash
+        run: |
+          bom generate --format=json -o /tmp/trusty-sdk-go-$TAG.spdx.json .
+      - name: Publish Release
+        uses: kubernetes-sigs/release-actions/publish-release@2f8b9ec22aedc9ce15039b6c7716aa6c2907df1c # v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          assets: "/tmp/trusty-sdk-go-$TAG.spdx.json"
+          sbom: false


### PR DESCRIPTION
This PR adds a release workflow to be executed on a `v*` tag push

Sample release:   https://github.com/puerco/trusty-sdk-go/releases/tag/v0.2.0-rc.2

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@stacklok.com>
