### PR TITLE
Allow users to specify a subset of options

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -68,8 +68,20 @@ func New() *Trusty {
 	return NewWithOptions(opts)
 }
 
-// NewWithOptions returns a new client with the dspecified options set
+// NewWithOptions returns a new client with the specified options set
 func NewWithOptions(opts Options) *Trusty {
+	if opts.BaseURL == "" {
+		opts.BaseURL = DefaultOptions.BaseURL
+	}
+
+	if opts.Workers == 0 {
+		opts.Workers = DefaultOptions.Workers
+	}
+
+	if opts.HttpClient == nil {
+		opts.HttpClient = khttp.NewAgent().WithMaxParallel(opts.Workers).WithFailOnHTTPError(true)
+	}
+
 	return &Trusty{
 		Options: opts,
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -62,6 +62,58 @@ func buildReader(s string) io.ReadCloser {
 	return io.NopCloser(stringReader)
 }
 
+func TestNewWithOptions(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name               string
+		constructorOptions Options
+		usedOptions        Options
+	}{
+		{
+			name: "defaults workers",
+			constructorOptions: Options{
+				BaseURL: "https://test.com",
+			},
+			usedOptions: Options{
+				BaseURL: "https://test.com",
+				Workers: DefaultOptions.Workers,
+			},
+		},
+		{
+			name: "defaults base URL",
+			constructorOptions: Options{
+				Workers: 1,
+			},
+			usedOptions: Options{
+				BaseURL: DefaultOptions.BaseURL,
+				Workers: 1,
+			},
+		},
+		{
+			name: "defaults http client",
+			constructorOptions: Options{
+				Workers: 1,
+				BaseURL: "https://test.com",
+			},
+			usedOptions: Options{
+				Workers: 1,
+				BaseURL: "https://test.com",
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client := NewWithOptions(tc.constructorOptions)
+
+			require.Equal(t, tc.usedOptions.BaseURL, client.Options.BaseURL)
+			require.Equal(t, tc.usedOptions.Workers, client.Options.Workers)
+			require.NotNil(t, client.Options.HttpClient)
+		})
+	}
+}
+
 func TestReport(t *testing.T) {
 	t.Parallel()
 	respBody := `{"package_name":"requestts","package_type":"pypi"}`


### PR DESCRIPTION
This defaults any unset options, when creating a new Trusty client. 
This also ensures the http client is not nil, which was causing an error in Minder.

Ref https://github.com/stacklok/minder/issues/4081