### PR TITLE
Honor Trusty package ingestion status

### DIFF
--- a/pkg/types/response.go
+++ b/pkg/types/response.go
@@ -80,6 +80,8 @@ type PackageData struct {
 	Archived   bool           `json:"archived"`
 	Deprecated bool           `json:"is_deprecated"`
 	Malicious  *MaliciousData `json:"malicious"`
+	Status     string         `json:"status"`
+	StatusCode string         `json:"status_code"`
 }
 
 // MaliciousData contains the security details when a dependency is malicious

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -35,6 +35,18 @@ const (
 
 	// ECOSYSTEM_PYPI identifies the Python Package Index
 	ECOSYSTEM_PYPI Ecosystem = 3
+
+	// IngestStatusFailed ingestion failed permanently
+	IngestStatusFailed = "failed"
+
+	// IngestStatusComplete means ingestion is done, data available
+	IngestStatusComplete = "complete"
+
+	// IngestStatusPending means that the ingestion process is waiting to start
+	IngestStatusPending = "pending"
+
+	// IngestStatusScoring means the scoring process is underway
+	IngestStatusScoring = "scoring"
 )
 
 // Ecosystems enumerates the supported ecosystems


### PR DESCRIPTION
This commit updates the trusty client to add retry capabilities in the single lookup logic to honor the ingestion status as reported by trusty.

Preparing for the deprecation of the v1 endpoints, this change matches the capabilities of the client logic in the trusty action. Once this merges we'll migrate the action to use the SDK client so that we have a single codebase to maintain (and port to v2)

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@stacklok.com>