### PR TITLE
Initial v2 Types for Objects and API responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.1
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/google/go-github/v61 v61.0.0
+	github.com/google/uuid v1.6.0
 	github.com/package-url/packageurl-go v0.1.3
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/oauth2 v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5p
 github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 h1:Up6+btDp321ZG5/zdSLo48H9Iaq0UQGthrhWC6pCxzE=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
 github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=

--- a/pkg/types/v2/objects/alternative.go
+++ b/pkg/types/v2/objects/alternative.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objects
+
+// Example: 'https://api.trustypkg.dev/v2/alternatives?package_name=react&package_type=npm'
+
+// AlternativePackage is a structure describing a package with similar capabilities
+// as another.
+type AlternativePackage struct {
+	PackageBrief
+}

--- a/pkg/types/v2/objects/contributor.go
+++ b/pkg/types/v2/objects/contributor.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objects
+
+import "github.com/google/uuid"
+
+// Contributor is a reusable structure that captures the information about a
+// user related to a package.
+type Contributor struct {
+	ID         *uuid.UUID `json:"ID"`
+	Author     *string
+	Email      *string `json:"author_email"`
+	Login      *string `json:"login"`
+	AvatarURL  *string `json:"avatar_url"`
+	GravatarID *string `json:"gravatar_id"`
+	URL        *string `json:"url"`
+	HTMLURL    *string `json:"html_url"`
+	Company    *string
+	Blog       *string
+	Location   *string
+	// Email *string  // email
+	Hireable        *bool
+	TwitterUsername *string `json:"ywitter_username"`
+	PublicRepos     *int
+	PublicGists     *int
+	Followers       *int
+	Following       *int
+	// Scores
+}

--- a/pkg/types/v2/objects/doc.go
+++ b/pkg/types/v2/objects/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package objects defines the data structures used by the Trusty API in its
+// responses. These data structures embed each other to abstract common
+// patterns.
+package objects

--- a/pkg/types/v2/objects/license.go
+++ b/pkg/types/v2/objects/license.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objects
+
+import "github.com/google/uuid"
+
+// LicenseIdentifier overrides string and captures an SPDX license identifier
+type LicenseIdentifier string
+
+// LicenseClaim is a struct that captures the licensing data from a package.
+type LicenseClaim struct {
+	ID          *uuid.UUID
+	OwnerID     *uuid.UUID           `json:"owner_id"`
+	Licenses    []*LicenseIdentifier `json:"licenses"`
+	Claim       *LicenseClaim
+	Content     *string // ?
+	URL         *string // ?
+	Source      *string
+	Description *string
+}

--- a/pkg/types/v2/objects/maliciousdata.go
+++ b/pkg/types/v2/objects/maliciousdata.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objects
+
+import "time"
+
+// MaliciousData contains the security details when a dependency is malicious
+type MaliciousData struct {
+	Summary   string     `json:"summary"`
+	Details   string     `json:"details"`
+	Published *time.Time `json:"published"`
+	Modified  *time.Time `json:"modified"`
+	Source    string     `json:"source"`
+}

--- a/pkg/types/v2/objects/package_brief.go
+++ b/pkg/types/v2/objects/package_brief.go
@@ -1,0 +1,30 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objects
+
+import "github.com/google/uuid"
+
+// PackageBrief is the smaller representation of a package. It is mainly used
+// in responses that ennumerate other packages.
+type PackageBrief struct {
+	ID              *uuid.UUID
+	Name            *string `json:"package_name"`
+	Type            *string `json:"package_type"`
+	Version         *string `json:"package_version"`
+	RepoDescription *string `json:"repo_description"`
+	Score           *float64
+	IsMalicious     *bool `json:"is_malicious"`
+	Provenance      *Provenance
+}

--- a/pkg/types/v2/objects/pkg.go
+++ b/pkg/types/v2/objects/pkg.go
@@ -1,0 +1,66 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objects
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Pkg is the full package information as returned from the  v2/pkg API call.
+// In contrast to PackageBrief this structure captures the complete data
+// that trusty knows about the described package.
+type Pkg struct {
+	ID               *uuid.UUID
+	Status           *string
+	StatusCode       *string
+	Name             *string
+	Type             *string
+	Version          *string
+	VersionDate      *time.Time
+	Author           *string
+	AuthorEmail      *string `json:"author_email"`
+	Description      *string `json:"packag_description"`
+	RepoDescription  *string `json:"repo_description"`
+	Origin           *string // What is this?
+	StarGazersCount  *int    `json:"stargazers_count"`
+	WatchersCount    *int    `json:"watchers_count"`
+	HomePage         *string `json:"home_page"`
+	HasIssues        *bool
+	HasProjects      *bool
+	HasDownloads     *bool
+	ForksCount       *int
+	Archived         *bool
+	Deprecated       *bool `json:"is_deprecated"`
+	Disabled         *bool `json:"disabled"`
+	OpenIssuesCount  *int  `json:"open_issues_count"`
+	Visibility       *string
+	DefaultBranch    *string    `json:"default_branch"`
+	RepositoryID     *uuid.UUID `json:"repository_id"`
+	RepositoryName   *string    `json:"repository_name"`
+	ContributorCount *int       `json:"contributor_count"`
+	PublicRepos      *int       `json:"public_repos"`
+	PublicGists      *int       `json:"public_gists"`
+	Followers        *int
+	Following        *int
+	Owner            *Contributor
+	Contributors     []*Contributor
+	LastUpdate       *time.Time `json:"last_update"`
+	// Scores
+	// "scores": {},
+	Malicious               *MaliciousData
+	HasTriggeredReingestion *bool
+}

--- a/pkg/types/v2/objects/provenance.go
+++ b/pkg/types/v2/objects/provenance.go
@@ -1,0 +1,48 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objects
+
+import "time"
+
+// Provenance has the package's provenance score and provenance type components
+type Provenance struct {
+	Score       float64               `json:"score"`
+	Description ProvenanceDescription `json:"description"`
+	UpdatedAt   *time.Time            `json:"updated_at"`
+}
+
+// ProvenanceDescription contians the provenance types
+type ProvenanceDescription struct {
+	Historical HistoricalProvenance `json:"hp"`
+	Sigstore   SigstoreProvenance   `json:"sigstore"`
+}
+
+// HistoricalProvenance has the historical provenance components from a package
+type HistoricalProvenance struct {
+	Tags     float64 `json:"tags"`
+	Common   float64 `json:"common"`
+	Overlap  float64 `json:"overlap"`
+	Versions float64 `json:"versions"`
+}
+
+// SigstoreProvenance has the sigstore certificate data when a package was signed
+// using a github actions workflow
+type SigstoreProvenance struct {
+	Issuer           string `json:"issuer"`
+	Workflow         string `json:"workflow"`
+	SourceRepository string `json:"source_repo"`
+	TokenIssuer      string `json:"token_issuer"`
+	Transparency     string `json:"transparency"`
+}

--- a/pkg/types/v2/objects/similar.go
+++ b/pkg/types/v2/objects/similar.go
@@ -1,0 +1,22 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objects
+
+// Example: 'https://api.trustypkg.dev/v2/similar?package_name=react&package_type=npm'
+
+// SimilarPackage describes a package with a name that is similar to another one.
+type SimilarPackage struct {
+	PackageBrief
+}

--- a/pkg/types/v2/responses/alternative.go
+++ b/pkg/types/v2/responses/alternative.go
@@ -1,0 +1,25 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package responses
+
+import "github.com/stacklok/trusty-sdk-go/pkg/types/v2/objects"
+
+// Example: 'https://api.trustypkg.dev/v2/alternatives?package_name=react&package_type=npm'
+
+// Alternatives captures the response from the v2/alternatives API call.
+type Alternatives struct {
+	Status   *string
+	Packages []*objects.AlternativePackage `json:"packages"`
+}

--- a/pkg/types/v2/responses/doc.go
+++ b/pkg/types/v2/responses/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package responses has the data structures toread the responses from the
+// Trusty API. These types use the structs defined in the v2/objects package.
+package responses

--- a/pkg/types/v2/responses/license.go
+++ b/pkg/types/v2/responses/license.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package responses
+
+import "github.com/stacklok/trusty-sdk-go/pkg/types/v2/objects"
+
+// License captures the response of the v2/license API call.
+type License struct {
+	License *objects.LicenseIdentifier
+	Claims  []*objects.LicenseClaim
+}

--- a/pkg/types/v2/responses/pkg.go
+++ b/pkg/types/v2/responses/pkg.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package responses
+
+import "github.com/stacklok/trusty-sdk-go/pkg/types/v2/objects"
+
+// Pkg captures the reply from the v2/pkg call. This API call returns the
+// full data about a pacakge known to Trusty.
+type Pkg struct {
+	objects.Pkg
+}

--- a/pkg/types/v2/responses/similar.go
+++ b/pkg/types/v2/responses/similar.go
@@ -1,0 +1,25 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package responses
+
+import "github.com/stacklok/trusty-sdk-go/pkg/types/v2/objects"
+
+// Example: 'https://api.trustypkg.dev/v2/similar?package_name=react&package_type=npm'
+
+// Similar is the response from the v2/similar API call. It is a list of packages
+// with names that sound similar to the queried package.
+type Similar struct {
+	Packages []*objects.SimilarPackage `json:"similar_package_names"`
+}


### PR DESCRIPTION
This PR adds two packages with the initial data structures to capture the following v2/apis:

- v2/alternative
- v2/license
- v2/pkg
- v2/similar

The response types build on the types defined on the objects package.

Note that this initial push of data types is subject to change along with the v2 API design, the main goal is to start structuring the packages and their files to quickly follow the API improvements.

